### PR TITLE
Changing URL of code-of-conduct page

### DIFF
--- a/.github/ISSUE_TEMPLATE/topic-idea.md
+++ b/.github/ISSUE_TEMPLATE/topic-idea.md
@@ -5,12 +5,6 @@ title: "Topic Idea: TOPIC TITLE"
 labels: Awaiting Triage, Needs Subject Matter Expert
 ---
 
-<!--
-The steps to translating content on Learn WordPress can be found in the handbook: https://make.wordpress.org/training/handbook/content-localization/.
-
-Remember to update the title of this issue. Example: Greek translation for Lesson Plan "Introduction To Common Plugins"
--->
-
 # Details
 <!-- Please describe what this content topic is about-->
 - Topic title: 

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -277,9 +277,9 @@ _x( 'Navigation Block Menu', 'Included Content term name', 'wporg-learn' );
 _x( 'page attributes', 'Included Content term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/wporg_included_content/pages/ */
 _x( 'pages', 'Included Content term name', 'wporg-learn' );
-/* translators: https://learn.wordpress.org/wporg_included_content/performance/ */
-_x( 'performance', 'Included Content term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/wporg_included_content/performance-settings/ */
+_x( 'performance', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/performance/ */
 _x( 'performance', 'Included Content term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/wporg_included_content/permalinks/ */
 _x( 'permalinks', 'Included Content term name', 'wporg-learn' );

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -387,8 +387,6 @@ _x( 'eCommerce', 'Topics term name', 'wporg-learn' );
 _x( 'Extending WordPress', 'Topics term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/topic/extending-wordpress/ */
 _x( 'Developing or customizing with code.', 'Topics term description', 'wporg-learn' );
-/* translators: https://learn.wordpress.org/topic/full-site-editing/ */
-_x( 'Full Site Editing', 'Topics term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/topic/general/ */
 _x( 'General', 'Topics term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/topic/general/ */
@@ -415,6 +413,8 @@ _x( 'Publishing', 'Topics term name', 'wporg-learn' );
 _x( 'RSS', 'Topics term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/topic/security/ */
 _x( 'Security', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/site-editor/ */
+_x( 'Site Editor', 'Topics term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/topic/site-management/ */
 _x( 'Site Management', 'Topics term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/topic/speaking-at-events/ */

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -277,9 +277,9 @@ _x( 'Navigation Block Menu', 'Included Content term name', 'wporg-learn' );
 _x( 'page attributes', 'Included Content term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/wporg_included_content/pages/ */
 _x( 'pages', 'Included Content term name', 'wporg-learn' );
-/* translators: https://learn.wordpress.org/wporg_included_content/performance-settings/ */
-_x( 'performance', 'Included Content term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/wporg_included_content/performance/ */
+_x( 'performance', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/performance-settings/ */
 _x( 'performance', 'Included Content term name', 'wporg-learn' );
 /* translators: https://learn.wordpress.org/wporg_included_content/permalinks/ */
 _x( 'permalinks', 'Included Content term name', 'wporg-learn' );


### PR DESCRIPTION
On the WordPress website on the code-of-conduct page (https://learn.wordpress.org/online-workshops/code-of-conduct/) page, on clicking the URL  http://opensourcebridge.org/about/code-of-conduct/ the page is not opening, this link needs to change to https://opensource.com/code-of-conduct.